### PR TITLE
fix get-pip.py url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         libgomp1 \
         python3 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bootstrap.pypa.io/3.5/get-pip.py | python3 - \
+    && curl -fsSL https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 - \
     && ln -s $(which python3) /usr/local/bin/python
 
 WORKDIR /opt/kwyk

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -34,7 +34,7 @@ RUN apt-get update \
         libgomp1 \
         python3 \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bootstrap.pypa.io/3.5/get-pip.py | python3 - \
+    && curl -fsSL https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 - \
     && ln -s $(which python3) /usr/local/bin/python
 
 WORKDIR /opt/kwyk


### PR DESCRIPTION
fixes #23 

This fixes the url to download the pip installer.