### PR TITLE
[WIP] multifile output issue & freesurfer conform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN pip install --no-cache-dir --editable .[cpu] \
     && curl -fsSL https://github.com/patrick-mcclure/nobrainer/tarball/master \
     | tar xz --strip=1 --wildcards '*/saved_models'
 
-ENV FREESURFER_HOME="/opt/kwyk/freesurfer"
-ENV PATH="$FREESURFER_HOME/bin:$PATH"
 
 WORKDIR /data
 ENTRYPOINT ["kwyk"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -43,10 +43,7 @@ RUN pip install --no-cache-dir --editable .[gpu] \
     # Install the saved models.
     && curl -fsSL https://github.com/patrick-mcclure/nobrainer/tarball/master \
     | tar xz --strip=1 --wildcards '*/saved_models'
-
-
-ENV FREESURFER_HOME="/opt/kwyk/freesurfer"
-ENV PATH="$FREESURFER_HOME/bin:$PATH"
+    
 
 WORKDIR /data
 ENTRYPOINT ["kwyk"]

--- a/freesurfer/bin/mri_convert
+++ b/freesurfer/bin/mri_convert
@@ -1,3 +1,0 @@
-#!/bin/bash
-source $FREESURFER_HOME/sources.sh
-mri_convert.bin "$@"

--- a/freesurfer/license.txt
+++ b/freesurfer/license.txt
@@ -1,4 +1,0 @@
-jakubk@mit.edu
-31682
- *C8rx5jxXpfDE
- FS3Si7CaSZoMo

--- a/kwyk/cli.py
+++ b/kwyk/cli.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import subprocess
 import tempfile
 import json
-import os
 
 import click
 import nibabel as nib
@@ -38,7 +37,7 @@ _models = {
 def predict(*, infiles, outprefix, model, n_samples, batch_size, save_variance, save_entropy, overwrite, atlocation):
     """Predict labels from features using a trained model.
 
-    The predictions are saved to OUTPREFIX_* with the same extension as the input file.
+    The predictions are saved to INFILE_OUTPREFIX_* with the same extension as the input file.
 
     If you encounter out-of-memory issues, use a lower batch size value.
     """
@@ -63,9 +62,12 @@ def _predict(infile, outprefix, predictor, n_samples, batch_size, save_variance,
     # Are there other neuroimaging file extensions with multiple periods?
     if infile.lower().endswith('.nii.gz'):
         outfile_ext = '.nii.gz'
+        infile_stem = infile.rsplit('.', 2)[0].rsplit("/",1)[-1]
     else:
         outfile_ext = Path(infile).suffix
-    outfile_stem = outprefix
+        infile_stem = infile.rsplit('.', 1)[0].rsplit("/",1)[-1]
+        
+    outfile_stem = "{}_{}".format(infile_stem, outprefix)
 
     if atlocation:
         outfile_stem = Path(infile).parent / outfile_stem

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,15 +23,15 @@ install_requires =
     click >= 7.0
     nobrainer @ git+https://github.com/patrick-mcclure/nobrainer@3bd95fa2f3cd24add9457d650165098fef180ec7
     etelemetry
-python_requires = >=3.5
+python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =
     kwyk = kwyk.cli:predict
 
 [options.extras_require]
-cpu = tensorflow == 1.12.3
-gpu = tensorflow-gpu == 1.12.3
+cpu = tensorflow == 1.15
+gpu = tensorflow-gpu == 1.15
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Changes:
- output file name adapted to enable save output files in the same directory.
- freesurefer conform replaced with nibabel.processing.conform.

@satra - there is a conflict between a python version required for `nibabel` and Tensorflow. Tensorflow 1.xx works with python 3.5 but nibabel version with processing.conform needs python version 3.6. 
any suggestion? 